### PR TITLE
Fix configuration retrieval in Startup

### DIFF
--- a/startup.cs
+++ b/startup.cs
@@ -10,11 +10,11 @@ public void ConfigureServices(IServiceCollection services)
   //GOOGLE
  services.AddAuthentication().AddGoogle(options =>
  {
-   var clientid = Configuration.GetSection("Authentication").GetSection("Google").GetValue(typeof(string), "ClientId");
-   options.ClientId = clientid.ToString();
+   var clientid = Configuration.GetValue<string>("Authentication:Google:ClientId");
+   options.ClientId = clientid;
   
-   var clientsecret = Configuration.GetSection("Authentication").GetSection("Google").GetValue(typeof(string), "ClientSecret");
-   options.ClientSecret = clientsecret.ToString();
+   var clientsecret = Configuration.GetValue<string>("Authentication:Google:ClientSecret");
+   options.ClientSecret = clientsecret;
   
   });
 }


### PR DESCRIPTION
## Summary
- simplify and strongly type config value retrieval for Google authentication

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684853475c248331a568a476b278407d