### PR TITLE
Add Google options test

### DIFF
--- a/startup.cs
+++ b/startup.cs
@@ -1,30 +1,34 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.Google;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
-public IConfiguration Configuration { get; }
-
- public Startup(IConfiguration configuration)
-{           
-       Configuration = configuration;
-}
-
-public void ConfigureServices(IServiceCollection services)
+public class Startup
 {
-  //GOOGLE
- services.AddAuthentication(options =>
-  {
-      options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-      options.DefaultChallengeScheme = GoogleDefaults.AuthenticationScheme;
-  })
-  .AddCookie()
-  .AddGoogle(options =>
-  {
-   var clientid = Configuration.GetValue<string>("Authentication:Google:ClientId");
-   options.ClientId = clientid;
+    public IConfiguration Configuration { get; }
 
-   var clientsecret = Configuration.GetValue<string>("Authentication:Google:ClientSecret");
-   options.ClientSecret = clientsecret;
+    public Startup(IConfiguration configuration)
+    {
+        Configuration = configuration;
+    }
 
-  });
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // GOOGLE
+        services.AddAuthentication(options =>
+        {
+            options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+            options.DefaultChallengeScheme = GoogleDefaults.AuthenticationScheme;
+        })
+        .AddCookie()
+        .AddGoogle(options =>
+        {
+            var clientid = Configuration.GetValue<string>("Authentication:Google:ClientId");
+            options.ClientId = clientid;
+
+            var clientsecret = Configuration.GetValue<string>("Authentication:Google:ClientSecret");
+            options.ClientSecret = clientsecret;
+        });
+    }
 }
-

--- a/tests/GoogleAuthTests/GoogleAuthTests.csproj
+++ b/tests/GoogleAuthTests/GoogleAuthTests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="../../startup.cs" Link="Startup.cs" />
+    <None Include="../../appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/tests/GoogleAuthTests/GoogleOptionsTests.cs
+++ b/tests/GoogleAuthTests/GoogleOptionsTests.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Authentication.Google;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System.Linq;
+using Xunit;
+
+public class GoogleOptionsTests
+{
+    [Fact]
+    public void ConfigureServices_BindsGoogleOptionsFromConfiguration()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json", optional: false)
+            .Build();
+
+        var services = new ServiceCollection();
+        var startup = new Startup(configuration);
+
+        // Act
+        startup.ConfigureServices(services);
+        var provider = services.BuildServiceProvider();
+
+        var configureOptions = provider.GetServices<IConfigureOptions<GoogleOptions>>();
+        var options = new GoogleOptions();
+        foreach (var configure in configureOptions)
+        {
+            configure.Configure(options);
+        }
+
+        // Assert
+        Assert.Equal(configuration["Authentication:Google:ClientId"], options.ClientId);
+        Assert.Equal(configuration["Authentication:Google:ClientSecret"], options.ClientSecret);
+    }
+}


### PR DESCRIPTION
## Summary
- convert Startup snippet into a compilable class
- add xUnit test project
- test that ConfigureServices binds Google options from `appsettings.json`

## Testing
- `dotnet test tests/GoogleAuthTests/GoogleAuthTests.csproj -v minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848573a79b883318aa89f4b37ff7bba