### PR TITLE
Add CI workflow for .NET tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: .NET Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '6.0.x'
+
+    - name: Restore dependencies
+      run: dotnet restore tests/GoogleAuthTests/GoogleAuthTests.csproj
+
+    - name: Build
+      run: dotnet build --no-restore tests/GoogleAuthTests/GoogleAuthTests.csproj
+
+    - name: Test
+      run: dotnet test --no-build --verbosity normal tests/GoogleAuthTests/GoogleAuthTests.csproj

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 This is a simple snippet on how to configure Google Authentication service in ASP.NET Core application by using a json settings file
 
 The Google credential key can be generated here: https://console.developers.google.com/apis/credentials
+
+## Continuous Integration
+
+This repository uses GitHub Actions to automatically run unit tests on each push or pull request to the `main` branch. The workflow file is located at `.github/workflows/ci.yml` and executes `dotnet test` against the test project.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `dotnet test`
- document CI setup in README

## Testing
- `dotnet test tests/GoogleAuthTests/GoogleAuthTests.csproj` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68485883f1788331a841809ef20d959d