### PR TITLE
Add cookie authentication package to test project

### DIFF
--- a/tests/GoogleAuthTests/GoogleAuthTests.csproj
+++ b/tests/GoogleAuthTests/GoogleAuthTests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- add a cookie authentication package reference to the test csproj

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486f8b4208833186ed4a11fbdb3c47